### PR TITLE
Always apply if no_diff is set to true

### DIFF
--- a/pkg/provider/resource_profile.go
+++ b/pkg/provider/resource_profile.go
@@ -426,7 +426,7 @@ func resourceProfileUpdate(
 		return diags
 	}
 
-	if len(diffValue) > 0 {
+	if len(diffValue) > 0 || data.Get("no_diff").(bool) {
 		expandResult, err := providerCtx.expand(ctx, data)
 		if err != nil {
 			diags = append(diags, diag.FromErr(err)...)


### PR DESCRIPTION
## Description
This change fixes the update logic in the provider to always apply if `no_diff` is set to `true`. Without this, updates are never applied in the `no_diff` case because the `diffValue` is always empty.

## Testing
Testing completed successfully via applying locally.