### PR TITLE
Use random configHash in kaexpand

### DIFF
--- a/cmd/kaexpand/main.go
+++ b/cmd/kaexpand/main.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/fatih/color"
 	"github.com/ghodss/yaml"
@@ -165,6 +167,7 @@ func (c kaExpandConfig) toClusterConfig() (*cluster.Config, error) {
 		AccountName: c.AccountName,
 		Environment: c.Environment,
 		Parameters:  map[string]interface{}{},
+		ConfigHash:  rand128Bits(),
 	}
 
 	for _, parameter := range c.Parameters {
@@ -191,6 +194,13 @@ func (c kaExpandConfig) toClusterConfig() (*cluster.Config, error) {
 	}
 
 	return clusterConfig, nil
+}
+
+func rand128Bits() string {
+	rand.Seed(time.Now().Unix())
+	high := rand.Uint64()
+	low := rand.Uint64()
+	return fmt.Sprintf("%08x%08x", high, low)
 }
 
 func runExpand(


### PR DESCRIPTION
The `kaexpand` command now generates a (non-secure) random 128-bit value
for the "configHash" value used in cluster configurations, so that
expansions that require the hash value can succeed. Notably, the hash is
not derived from any files or parameters, and will change with every
execution.