### PR TITLE
Upgrade default authentication API version to v1beta1

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -160,6 +160,6 @@ Required:
 
 Optional:
 
-- `api_version` - (String) API version, e.g. `client.authentication.k8s.io/v1beta1` __IMPORTANT__: For EKS, if you use `aws`CLI v1.24+, you can leave this as the default (`v1beta1`). If you use `aws`CLI >=v1.23, you will need to manually set this value to `client.authentication.k8s.io/v1alpha1` for versions of this provider after `0.0.12`. 
+- `api_version` - (String) API version, e.g. `client.authentication.k8s.io/v1beta1` __IMPORTANT__: For EKS, if you use `aws`CLI v1.24+ or 2.6.3+, you can leave this as the default (`v1beta1`). If you use `aws`CLI <=v1.23 or <2.6.3 , you will need to manually set this value to `client.authentication.k8s.io/v1alpha1` for versions of this provider after `0.0.12`. 
 - `args` - (List of String) List of args to pass to command
 - `env` - (Map of String) Environment variables to set

--- a/docs/index.md
+++ b/docs/index.md
@@ -160,6 +160,6 @@ Required:
 
 Optional:
 
-- `api_version` - (String) API version, e.g. `client.authentication.k8s.io/v1beta1`
+- `api_version` - (String) API version, e.g. `client.authentication.k8s.io/v1beta1` __IMPORTANT__: For EKS, if you use `aws`CLI v1.24+, you can leave this as the default (`v1beta1`). If you use `aws`CLI >=v1.23, you will need to manually set this value to `client.authentication.k8s.io/v1alpha1` for versions of this provider after `0.0.12`. 
 - `args` - (List of String) List of args to pass to command
 - `env` - (Map of String) Environment variables to set

--- a/docs/index.md
+++ b/docs/index.md
@@ -160,6 +160,6 @@ Required:
 
 Optional:
 
-- `api_version` - (String) API version, e.g. `client.authentication.k8s.io/v1alpha1`
+- `api_version` - (String) API version, e.g. `client.authentication.k8s.io/v1beta1`
 - `args` - (List of String) List of args to pass to command
 - `env` - (Map of String) Environment variables to set

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -94,7 +94,7 @@ func Provider(providerCtx *providerContext) *schema.Provider {
 						"api_version": {
 							Type:     schema.TypeString,
 							Optional: true,
-							Default:  "client.authentication.k8s.io/v1alpha1",
+							Default:  "client.authentication.k8s.io/v1beta1",
 						},
 						"command": {
 							Type:     schema.TypeString,

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -29,7 +29,7 @@ func TestProviderTokenExec(t *testing.T) {
 			"token":                  "testToken",
 			"exec": []interface{}{
 				map[string]interface{}{
-					"api_version": "client.authentication.k8s.io/v1alpha1",
+					"api_version": "client.authentication.k8s.io/v1beta1",
 					"command":     "testCommand",
 					"env": map[string]interface{}{
 						"key1": "value1",
@@ -80,7 +80,7 @@ users:
   user:
     token: testToken
     exec:
-      apiVersion: client.authentication.k8s.io/v1alpha1
+      apiVersion: client.authentication.k8s.io/v1beta1
       command: testCommand
       env:
       - name: "key1"

--- a/pkg/provider/resource_profile_test.go
+++ b/pkg/provider/resource_profile_test.go
@@ -90,7 +90,7 @@ provider "kubeapply" {
   cluster_ca_certificate = "testCACertificate"
   token = "testToken"
   exec {
-    api_version = "client.authentication.k8s.io/v1alpha1"
+    api_version = "client.authentication.k8s.io/v1beta1"
     args        = ["eks", "get-token", "--cluster-name", "testCluster"]
     command     = "aws"
   }
@@ -131,7 +131,7 @@ provider "kubeapply" {
   cluster_ca_certificate = "testCACertificate"
   token = "testToken"
   exec {
-    api_version = "client.authentication.k8s.io/v1alpha1"
+    api_version = "client.authentication.k8s.io/v1beta1"
     args        = ["eks", "get-token", "--cluster-name", "testCluster"]
     command     = "aws"
   }
@@ -165,7 +165,7 @@ provider "kubeapply" {
   cluster_ca_certificate = "testCACertificate"
   token = "testToken"
   exec {
-    api_version = "client.authentication.k8s.io/v1alpha1"
+    api_version = "client.authentication.k8s.io/v1beta1"
     args        = ["eks", "get-token", "--cluster-name", "testCluster"]
     command     = "aws"
   }
@@ -193,7 +193,7 @@ provider "kubeapply" {
   cluster_ca_certificate = "testCACertificate"
   token = "testToken"
   exec {
-    api_version = "client.authentication.k8s.io/v1alpha1"
+    api_version = "client.authentication.k8s.io/v1beta1"
     args        = ["eks", "get-token", "--cluster-name", "testCluster"]
     command     = "aws"
   }
@@ -227,7 +227,7 @@ provider "kubeapply" {
   cluster_ca_certificate = "testCACertificate"
   token = "testToken"
   exec {
-    api_version = "client.authentication.k8s.io/v1alpha1"
+    api_version = "client.authentication.k8s.io/v1beta1"
     args        = ["eks", "get-token", "--cluster-name", "testCluster"]
     command     = "aws"
   }


### PR DESCRIPTION
In Kubernetes 1.24 (and associated client versions), the authentication
v1alpha1 API version no longer exists. This bumps the default to v1beta1