### PR TITLE
BGLRINFRA-1069: Upgraded the api apiextensions.k8s.io/v1beta to apiextensions.k8s.io/v1

### DIFF
--- a/pkg/cluster/kube/manifests_test.go
+++ b/pkg/cluster/kube/manifests_test.go
@@ -16,16 +16,20 @@ const (
 
 ---
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: pod-log-reader
 rules:
-- apiGroups: [""]
+- apiGroups:
+  - ""
   resources:
-    - namespaces
-    - pods
-  verbs: ["get", "list", "watch"]
+  - namespaces
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -35,7 +39,7 @@ metadata:
   annotations:
     eks.amazonaws.com/role-arn: arn:aws:iam::184402915685:role/ob-yolken.usw2.eks.fluentbit
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: pod-log-crb

--- a/pkg/cluster/kube/manifests_test.go
+++ b/pkg/cluster/kube/manifests_test.go
@@ -122,13 +122,13 @@ func TestManifestIDToComponents(t *testing.T) {
 	assert.Equal(
 		t,
 		idComponents{
-			api:       "apiextensions.k8s.io/v1beta1",
+			api:       "apiextensions.k8s.io/v1",
 			kind:      "CustomResourceDefinition",
 			namespace: "",
 			name:      "analysisruns.argoproj.io",
 		},
 		manifestIDToComponents(
-			"apiextensions.k8s.io/v1beta1.CustomResourceDefinition..analysisruns.argoproj.io",
+			"apiextensions.k8s.io/v1.CustomResourceDefinition..analysisruns.argoproj.io",
 		),
 	)
 	assert.Equal(


### PR DESCRIPTION
### Description

This PR consist of the below changes:
Some of the APIs are getting upgrades like kube-system and monitoring bundle helm charts to make it compatible with 1.22.
So, we are migrating the APIs like apiextensions.k8s.io/v1beta to apiextensions.k8s.io/v1.

### Testing
Not required.